### PR TITLE
Set project by environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# PluralDo, a simple system-focussed task tracking system
+
+PluralDo is a simple task-tracking tool for systems, allowing for creating
+tasks and assigning them to other system members, writing descriptions, and
+simple project creation.
+
+## Usage
+
+...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "pluraldo"
 version = "0.1.0"
 description = "todo for plurals"
 authors = [
-    {name = "Jamie Bliss",email = "jamie@ivyleav.es"}
+    {name = "Jamie Bliss",email = "jamie@ivyleav.es"},
+    {name = "Aurynn Shaw",email = "self@aurynn.com"}
 ]
 readme = "README.md"
 requires-python = ">=3.11,<4"

--- a/src/pluraldo/pstore.py
+++ b/src/pluraldo/pstore.py
@@ -57,7 +57,7 @@ class PStore:
         ## todo:
         # this is a magic string being pulled from the environment, and 
         #   that is very much not ideal.
-        if os.environ.get("PLURALDO_PROJECT", None):
+        if "PLURALDO_PROJECT" in os.environ:
             proj = os.environ["PLURALDO_PROJECT"].upper()
             return proj
         try:

--- a/src/pluraldo/pstore.py
+++ b/src/pluraldo/pstore.py
@@ -4,6 +4,7 @@ Storage, but in pluraldo's terms
 
 import contextlib
 import typing
+import os
 
 import anyio
 import platformdirs
@@ -49,6 +50,16 @@ class PStore:
             doc["Front"] = name
 
     async def get_project(self) -> str | None:
+        # Get the current project. If the environment variable
+        #   `PLURALDO_PROJECT` is set, use that. Otherwise, use the currently
+        #   set project.
+        
+        ## todo:
+        # this is a magic string being pulled from the environment, and 
+        #   that is very much not ideal.
+        if os.environ.get("PLURALDO_PROJECT", None):
+            proj = os.environ["PLURALDO_PROJECT"].upper()
+            return proj
         try:
             doc = await self._store.get("_context")
             proj = doc["Current-Project"]


### PR DESCRIPTION
Check if the `PLURALDO_PROJECT` environment variable is set, and prefers that to the currently set project, allowing for dynamic project switching using tools like `direnv`.

Resolves #3.