### PR TITLE
Add `project` namespace, `ls` and `set` commands

### DIFF
--- a/src/pluraldo/__init__.py
+++ b/src/pluraldo/__init__.py
@@ -51,20 +51,45 @@ async def switch(name):
 
 
 @cli.command()
-@click.argument("project", required=False)
 @entry
-async def workon(project):
+async def clear():
     """
-    Change the current project, or unset it
+    Clears the current project
     """
-    if project:
-        project = project.upper()
+    ps = await PStore.get()
+    await ps.set_project(None)
+    click.echo("=> cleared project")
+
+
+@cli.group()
+def project():
+    """
+    Manage projects
+    """
+
+
+@project.command("set")
+@click.argument("project")
+@entry
+async def project_set(project):
+    """
+    Change the current project
+    """
     ps = await PStore.get()
     await ps.set_project(project)
     if project:
         click.echo(f"=> working on {project}")
-    else:
-        click.echo("=> cleared project")
+
+
+@project.command("ls")
+@entry
+async def project_ls():
+    """
+    List projects
+    """
+    ps = await PStore.get()
+    async for project in ps.get_projects():
+        click.echo(f"{project}")
 
 
 @cli.group()

--- a/src/pluraldo/pstore.py
+++ b/src/pluraldo/pstore.py
@@ -48,6 +48,20 @@ class PStore:
             del doc["Front"]
             doc["Front"] = name
 
+    async def get_projects(self) -> typing.AsyncIterator[str]:
+        """
+        Enumerate projects by name
+        """
+        projects = set()
+        async for fn in self._store.keys():
+            if fn == "_context":
+                # Skip the context file
+                continue
+            proj, _ = fn.split("-")
+            if proj not in projects:
+                projects.add(proj)
+                yield proj
+
     async def get_project(self) -> str | None:
         try:
             doc = await self._store.get("_context")

--- a/src/pluraldo/pstore.py
+++ b/src/pluraldo/pstore.py
@@ -54,7 +54,7 @@ class PStore:
         """
         projects = set()
         async for fn in self._store.keys():
-            if fn == "_context":
+            if "-" not in fn:
                 # Skip the context file
                 continue
             proj, _ = fn.split("-")


### PR DESCRIPTION
Remove `workon` command.

Add `project ls` and `project set` commands to list projects switch current project, respectively. Add `clear` to clear the current project.

Fixes #2 